### PR TITLE
use blastclust hit tables for reclustering

### DIFF
--- a/sh_matching_analysis/scripts/blastclust_formatter2.pl
+++ b/sh_matching_analysis/scripts/blastclust_formatter2.pl
@@ -18,6 +18,7 @@ for (my $k=0; $k<scalar(@files); $k++) {
     my $name = $files[$k];
     my $ucl_code = (split '\/', $name)[-1];
     my $name_out_97 = $name . "_out_97";
+    my $name_hitlist_97 = $name . "_hitlist_97"
     my $name_out_975 = $name . "_out_975";
     my $name_out_98 = $name . "_out_98";
     my $name_out_985 = $name . "_out_985";
@@ -25,19 +26,19 @@ for (my $k=0; $k<scalar(@files); $k++) {
     my $name_out_995 = $name . "_out_995";
     my $name_out_100 = $name . "_out_100";
 
-    my $system_command1 = $bc_location . " -i " . $name . " -S 97 -L 0.95 -b F -a 8 -e F -W 16 -o " . $name_out_97 . " -p F";
+    my $system_command1 = $bc_location . " -i " . $name . " -S 97 -L 0.95 -b F -a 8 -e F -W 16 -o " . $name_out_97 . " -p F -s " . $name_hitlist_97;
     system($system_command1);
-    my $system_command15 = $bc_location . " -i " . $name . " -S 97.5 -L 0.95 -b F -a 8 -e F -W 16 -o " . $name_out_975 . " -p F";
+    my $system_command15 = $bc_location . " -r " . $name_hitlist_97 . " -l " . $name_out_97 . " -S 97.5 -L 0.95 -b F -a 8 -e F -W 16 -o " . $name_out_975 . " -p F";
     system($system_command15);
-    my $system_command2 = $bc_location . " -i " . $name . " -S 98 -L 0.95 -b F -a 8 -e F -W 16 -o " . $name_out_98 . " -p F";
+    my $system_command2 = $bc_location . " -r " . $name_hitlist_97 . " -l " . $name_out_975 . " -S 98 -L 0.95 -b F -a 8 -e F -W 16 -o " . $name_out_98 . " -p F";
     system($system_command2);
-    my $system_command25 = $bc_location . " -i " . $name . " -S 98.5 -L 0.95 -b F -a 8 -e F -W 16 -o " . $name_out_985 . " -p F";
+    my $system_command25 = $bc_location . " -r " . $name_hitlist_97 . " -l " . $name_out_98 . " -S 98.5 -L 0.95 -b F -a 8 -e F -W 16 -o " . $name_out_985 . " -p F";
     system($system_command25);
-    my $system_command3 = $bc_location . " -i " . $name . " -S 99 -L 0.95 -b F -a 8 -e F -W 16 -o " . $name_out_99 . " -p F";
+    my $system_command3 = $bc_location . " -r " . $name_hitlist_97 . " -l " . $name_out_985 . " -S 99 -L 0.95 -b F -a 8 -e F -W 16 -o " . $name_out_99 . " -p F";
     system($system_command3);
-    my $system_command35 = $bc_location . " -i " . $name . " -S 99.5 -L 0.95 -b F -a 8 -e F -W 16 -o " . $name_out_995 . " -p F";
+    my $system_command35 = $bc_location . " -r " . $name_hitlist_97 . " -l " . $name_out_99 . " -S 99.5 -L 0.95 -b F -a 8 -e F -W 16 -o " . $name_out_995 . " -p F";
     system($system_command35);
-    my $system_command4 = $bc_location . " -i " . $name . " -S 100 -L 0.95 -b F -a 8 -e F -W 16 -o " . $name_out_100 . " -p F";
+    my $system_command4 = $bc_location . " -r " . $name_hitlist_97 . " -l " . $name_out_995 . " -S 100 -L 0.95 -b F -a 8 -e F -W 16 -o " . $name_out_100 . " -p F";
     system($system_command4);
 }
 

--- a/sh_matching_analysis/scripts/blastclust_formatter2_1.pl
+++ b/sh_matching_analysis/scripts/blastclust_formatter2_1.pl
@@ -17,6 +17,7 @@ my @files = glob($check_folder);
 for (my $k=0; $k<scalar(@files); $k++) {
     my $name = $files[$k];
     my $name_out_97 = $name . "_out_97";
+    my $name_hitlist_97 = $name . "_hitlist_97"
     my $name_out_975 = $name . "_out_975";
     my $name_out_98 = $name . "_out_98";
     my $name_out_985 = $name . "_out_985";
@@ -24,19 +25,19 @@ for (my $k=0; $k<scalar(@files); $k++) {
     my $name_out_995 = $name . "_out_995";
     my $name_out_100 = $name . "_out_100";
 
-    my $system_command1 = $bc_location . " -i " . $name . " -S 97 -L 0.95 -b F -a 8 -e F -W 16 -o " . $name_out_97 . " -p F";
+    my $system_command1 = $bc_location . " -i " . $name . " -S 97 -L 0.95 -b F -a 8 -e F -W 16 -o " . $name_out_97 . " -p F -s " . $name_hitlist_97;
     system($system_command1);
-    my $system_command15 = $bc_location . " -i " . $name . " -S 97.5 -L 0.95 -b F -a 8 -e F -W 16 -o " . $name_out_975 . " -p F";
+    my $system_command15 = $bc_location . " -r " . $name_hitlist_97 . " -l " . $name_out_97 . " -S 97.5 -L 0.95 -b F -a 8 -e F -W 16 -o " . $name_out_975 . " -p F";
     system($system_command15);
-    my $system_command2 = $bc_location . " -i " . $name . " -S 98 -L 0.95 -b F -a 8 -e F -W 16 -o " . $name_out_98 . " -p F";
+    my $system_command2 = $bc_location . " -r " . $name_hitlist_97 . " -l " . $name_out_975 . " -S 98 -L 0.95 -b F -a 8 -e F -W 16 -o " . $name_out_98 . " -p F";
     system($system_command2);
-    my $system_command25 = $bc_location . " -i " . $name . " -S 98.5 -L 0.95 -b F -a 8 -e F -W 16 -o " . $name_out_985 . " -p F";
+    my $system_command25 = $bc_location . " -r " . $name_hitlist_97 . " -l " . $name_out_98 . " -S 98.5 -L 0.95 -b F -a 8 -e F -W 16 -o " . $name_out_985 . " -p F";
     system($system_command25);
-    my $system_command3 = $bc_location . " -i " . $name . " -S 99 -L 0.95 -b F -a 8 -e F -W 16 -o " . $name_out_99 . " -p F";
+    my $system_command3 = $bc_location . " -r " . $name_hitlist_97 . " -l " . $name_out_985 . " -S 99 -L 0.95 -b F -a 8 -e F -W 16 -o " . $name_out_99 . " -p F";
     system($system_command3);
-    my $system_command35 = $bc_location . " -i " . $name . " -S 99.5 -L 0.95 -b F -a 8 -e F -W 16 -o " . $name_out_995 . " -p F";
+    my $system_command35 = $bc_location . " -r " . $name_hitlist_97 . " -l " . $name_out_99 . " -S 99.5 -L 0.95 -b F -a 8 -e F -W 16 -o " . $name_out_995 . " -p F";
     system($system_command35);
-    my $system_command4 = $bc_location . " -i " . $name . " -S 100 -L 0.95 -b F -a 8 -e F -W 16 -o " . $name_out_100 . " -p F";
+    my $system_command4 = $bc_location . " -r " . $name_hitlist_97 . " -l " . $name_out_995 . " -S 100 -L 0.95 -b F -a 8 -e F -W 16 -o " . $name_out_100 . " -p F";
     system($system_command4);
 }
 


### PR DESCRIPTION
The combination of caching the blastclust hit table from the 97% clustering steps, and using the results of previous clustering steps to constrain the future clustering, makes a dramatic improvement in the speed of SH construction.  I haven't tested thoroughly, but after caching the table, the 97.5%-100% clustering steps take only a few seconds, even for the large preclusters which dominate the overall run time, so the overall speedup should be around 7x.

The size of the hit table of course depends on the data, scaling as n<sup>2</sup> and the sparseness of the clustering.  In my dataset (with 60k unique sequences, larger than allowed on the current web service) the largest hit tables, for preclusters of ~12k sequences, are about 3Gb.  I'm not sure whether the disk space/time tradeoff (or possibly IO/CPU tradeoff) makes this worthwhile for the web service version or not; perhaps this has already been considered and rejected.