### PR TITLE
Update `sh_matching.def` - remove vsearch*.tar.gz

### DIFF
--- a/sh_matching.def
+++ b/sh_matching.def
@@ -38,6 +38,7 @@ A base Ubuntu 20 Singularity container with basic Python packages such as HMMER3
     wget https://github.com/torognes/vsearch/releases/download/v2.22.1/vsearch-2.22.1-linux-x86_64.tar.gz
     tar -xvf vsearch-2.22.1-linux-x86_64.tar.gz -C /sh_matching/programs/
     mv /sh_matching/programs/vsearch-2.22.1-linux-x86_64 /sh_matching/programs/vsearch
+    rm vsearch-2.22.1-linux-x86_64.tar.gz
 
     # ITSx 1.1.3
     wget https://microbiology.se/sw/ITSx_1.1.3.tar.gz


### PR DESCRIPTION
This PR removes a redundant archive of VSEARCH binary from the container.