### PR TITLE
`exclude_chims` - Simplify alignment coverage conditions

### DIFF
--- a/sh_matching_analysis/scripts/exclude_chims.py
+++ b/sh_matching_analysis/scripts/exclude_chims.py
@@ -72,9 +72,7 @@ with open(ex_file, "a") as ex, open(global_infile) as glob:
             perc_alignment_cov = len_alignment * 100 / len_of_query_cov
             perc_alignment_cov_target = len_alignment * 100 / len_of_target_cov
 
-            if perc_alignment_cov <= 80 and perc_alignment_cov_target <= 80:
-                global_chim_dict[row[0]] = 1
-            elif perc_alignment_cov <= 85 and perc_alignment_cov_target <= 85:
+            if perc_alignment_cov <= 85 and perc_alignment_cov_target <= 85:
                 global_chim_dict[row[0]] = 1
             elif int(row[3]) < len_limit_1 and int(row[7]) >= len_limit_1:
                 global_chim_dict[row[0]] = 1


### PR DESCRIPTION
Hello Kessy,

In the `exclude_chims` script, there are two separate conditions to check the percentage of alignment coverage, one for **<= 80** and another for **<= 85**. However, since the action taken in both cases is the same, this creates redundancy in the code.

https://github.com/TU-NHM/sh_matching_pub/blob/8eba0f6ac3ed0e5418602c8216aac9b2f71355e8/sh_matching_analysis/scripts/exclude_chims.py#L75-L80

Proposal:

It is possible to merge these two conditions into a single condition that checks just **<= 85** (whcih already encompass both the <= 80 and <= 85 scenarios):

``` pyhon
if perc_alignment_cov <= 85 and perc_alignment_cov_target <= 85:
    global_chim_dict[row[0]] = 1
elif int(row[3]) < len_limit_1 and int(row[7]) >= len_limit_1:
    global_chim_dict[row[0]] = 1
```

